### PR TITLE
mkdirall

### DIFF
--- a/pkg/taxonomies/taxonomies.go
+++ b/pkg/taxonomies/taxonomies.go
@@ -35,6 +35,13 @@ func NewTaxonomy(tm Meta, bytes []byte) (string, error) {
 	}
 	serializables.VolumePath = VolumePath
 	workingDir := filepath.Join(VolumePath, "taxonomies")
+	_, err = os.Stat(workingDir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(workingDir, 0755)
+		if err != nil {
+			return "", err
+		}
+	}
 	id := uuid.New()
 	pathStr := filepath.Join(workingDir, id.String())
 	_, err = os.Stat(pathStr)


### PR DESCRIPTION
fixes `mkdir /Users/joshuanario/Documents/GitHub/telefacts-taxonomy-package/test/data/taxonomies/c8cb1f14-926f-4a5e-b36e-6c7da0360272: no such file or directory`